### PR TITLE
Fixed a minor bug when a dhcpscope contains a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- abrauns-silex - 2025-05-14 - Version 1.0.14
+  * Fixed a minor bug when a dhcpscope contains a space in `dhcpscope` and `dhcpscope_info`
+
 - abrauns-silex - 2025-04-08 - Version 1.0.13
   * Added dhcpscope_info module
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: menandmice
 name: ansible_micetro
-version: 1.0.13
+version: 1.0.14
 readme: README.md
 authors:
   - Ton Kersten <t.kersten@atcomputing.nl>

--- a/plugins/modules/dhcpscope.py
+++ b/plugins/modules/dhcpscope.py
@@ -243,7 +243,10 @@ def run_module():
     for dhcp_server_ref in dhcp_server_refs:
 
         # Look up DHCP scope
-        refs = "DHCPScopes?filter=name=%s%%20AND%%20rangeRef=%s%%20AND%%20dhcpServerRef=%s" % (name, range_ref, dhcp_server_ref)
+        refs = (
+            'DHCPScopes?filter=name="%s"%%20AND%%20rangeRef=%s%%20AND%%20dhcpServerRef=%s'
+            % (name.replace(" ", "%20"), range_ref, dhcp_server_ref)
+        )
         resp = get_single_refs(refs, mm_provider)
         if resp.get("invalid", None):
             module.fail_json(

--- a/plugins/modules/dhcpscope_info.py
+++ b/plugins/modules/dhcpscope_info.py
@@ -239,7 +239,7 @@ def run_module():
     # Generate URL for API call
     query = ["DHCPScopes?"]
     if name:
-        query.append("filter=name=%s%s" % (search_method, name))
+        query.append('filter=name=%s"%s"' % (search_method, name.replace(" ", "%20")))
 
     if limit:
         query.append("limit=%s" % (limit))


### PR DESCRIPTION
# Overview

This pull request introduces a bug fix to the `dhcpscope` and `dhcpscope_info` modules. Currently, if a dhcpscope contains a space, the module will not work properly. 

## Changes Made

### Bug fixes

- The `dhcpscope` and `dhcpscope_info` modules will properly handle scopes that contain a name

### Increased collection version

- Collection version increased to 1.0.14